### PR TITLE
커뮤니티: 실천일지, 토론글, 자유글 수정 api 연동

### DIFF
--- a/src/apis/community/community.ts
+++ b/src/apis/community/community.ts
@@ -163,6 +163,68 @@ export const deletePost = (
   return instance.delete(url);
 };
 
+//자유글 수정 api
+export const editFreeBoard = async (
+  id: number,
+  data: CreateFreeBoardParams
+) => {
+  const formData = new FormData();
+
+  data.images?.forEach((img) => {
+    formData.append("images", img);
+  });
+
+  const res = await instance.put(`/api/v1/free-board/${id}`, formData, {
+    params: {
+      title: data.title,
+      content: data.content,
+    },
+  });
+
+  return res.data;
+};
+
+//토론글 수정 api
+export const editDiscussBoard = async (
+  id: number,
+  data: CreateDiscussBoardParams
+) => {
+  const formData = new FormData();
+
+  data.images?.forEach((img) => {
+    formData.append("images", img);
+  });
+
+  const res = await instance.put(`/api/v1/discuss-board/${id}`, formData, {
+    params: {
+      title: data.title,
+      content: data.content,
+      discussType: data.discussType,
+    },
+  });
+
+  return res.data;
+};
+
+//실천일지 수정 api
+export const editDiaryBoard = async (id: number, data: CreateDiaryParams) => {
+  const formData = new FormData();
+
+  data.images?.forEach((img) => {
+    formData.append("images", img);
+  });
+
+  const res = await instance.put(`/api/v1/diary/${id}`, formData, {
+    params: {
+      title: data.title,
+      content: data.content,
+      action: data.practiceCategory,
+    },
+  });
+
+  return res.data;
+};
+
 // 게시글 좋아요 토글
 export const toggleLike = (targetType: string, targetId: number) => {
   return instance.post<ToggleLikeResponse>("/api/v1/like/toggle", {
@@ -244,9 +306,12 @@ export const createFreeComment = async (postId: number, comment: string) => {
 
 //자유게시글 댓글 수정
 export const editFreeComment = async (commentId: number, comment: string) => {
-  const { data } = await instance.put(`/api/v1/free-board/comment/${commentId}`, {
-    comment,
-  });
+  const { data } = await instance.put(
+    `/api/v1/free-board/comment/${commentId}`,
+    {
+      comment,
+    }
+  );
 
   return data;
 };

--- a/src/components/Card/PreviewCard/index.tsx
+++ b/src/components/Card/PreviewCard/index.tsx
@@ -3,6 +3,7 @@ import $ from "./PreviewCard.module.scss";
 import { AiOutlineHeart, AiFillHeart } from "react-icons/ai";
 import { toggleLike } from "@/apis/community/community";
 import { toast } from "react-toastify";
+import { useNavigate } from "react-router-dom";
 
 export interface Preview {
   id: number;
@@ -38,6 +39,7 @@ const PreviewCard = ({
   onClick,
   onDelete,
 }: PreviewCardProps) => {
+  const navigate = useNavigate();
   const [isLiked, setIsLiked] = useState(post.liked || false);
 
   const handleLike = async (e: React.MouseEvent) => {
@@ -57,10 +59,21 @@ const PreviewCard = ({
     }
   };
 
+  const handleEdit = (e: React.MouseEvent) => {
+    e.stopPropagation();
+    navigate(`${editPaths[type]}?id=${post.id}`);
+  };
+
   const displayCategory =
     type === "debate" && post.category
       ? discussTypeMap[post.category] || post.category
       : post.category;
+
+  const editPaths = {
+    free: "/free/new",
+    debate: "/debate/new",
+    diary: "/diary/new",
+  };
 
   return (
     <div className={$.postCard} onClick={onClick}>
@@ -94,7 +107,7 @@ const PreviewCard = ({
         <div className={$.right}>
           {owner && (
             <div className={$.actions}>
-              <button>수정</button>
+              <button onClick={handleEdit}>수정</button>
               <span className={$.divider}>|</span>
               <button
                 onClick={(e) => {

--- a/src/pages/community/components/PostEditor.tsx
+++ b/src/pages/community/components/PostEditor.tsx
@@ -9,6 +9,7 @@ import Button from "@/components/common/Button";
 import { toast } from "react-toastify";
 
 export interface PostEditorProps<T extends string> {
+  mode?: "create" | "edit";
   type: "diary" | "free" | "debate";
   title: string;
   dropdownLabel?: string;
@@ -35,9 +36,11 @@ export default function PostEditor<T extends string>({
   dropdownOptions,
   onSubmit,
   defaultValues,
-  submitText = "작성 완료",
+  submitText,
+  mode,
 }: PostEditorProps<T>) {
   const navigate = useNavigate();
+  submitText = mode === "edit" ? "수정하기" : "작성 완료";
 
   const [postTitle, setPostTitle] = useState(defaultValues?.title || "");
   const [content, setContent] = useState(defaultValues?.content || "");

--- a/src/pages/community/components/detail/index.tsx
+++ b/src/pages/community/components/detail/index.tsx
@@ -164,6 +164,11 @@ export default function PostDetail({
       toast("잠시 후 다시 시도해주세요.");
     }
   };
+  const editPaths = {
+    free: "/free/new",
+    debate: "/debate/new",
+    diary: "/diary/new",
+  };
 
   return (
     <div className={$.wrapper}>
@@ -173,7 +178,11 @@ export default function PostDetail({
       <div className={$.container}>
         {owner && (
           <div className={$.actions}>
-            <button onClick={() => navigate("edit")}>수정</button>
+            <button
+              onClick={() => navigate(`${editPaths[type]}?id=${numericId}`)}
+            >
+              수정
+            </button>
             <span className={$.divider}>|</span>
             <button onClick={handleDelete}>삭제</button>
           </div>

--- a/src/pages/community/free/FreePostPage.tsx
+++ b/src/pages/community/free/FreePostPage.tsx
@@ -1,11 +1,49 @@
-import { useNavigate } from "react-router-dom";
+import { useNavigate, useSearchParams } from "react-router-dom";
+import { useEffect, useState } from "react";
 import PostEditor from "../components/PostEditor";
 import { compressImages } from "@/utils/imageCompressor";
-import { createFreeBoard } from "@/apis/community/community";
+import {
+  createFreeBoard,
+  getFreeBoardDetail,
+  editFreeBoard,
+} from "@/apis/community/community";
 import type { PostEditorFormData } from "../components/detail";
 
 export default function FreePostPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const id = searchParams.get("id");
+  const isEdit = Boolean(id);
+
+  const [defaultValues, setDefaultValues] = useState<PostEditorFormData | null>(
+    null
+  );
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!isEdit) return;
+
+    const fetchData = async () => {
+      setLoading(true);
+      try {
+        const res = await getFreeBoardDetail(id!);
+        const post = res.data;
+        setDefaultValues({
+          title: post.title,
+          content: post.content,
+          images: [],
+        });
+      } catch (e) {
+        console.error(e);
+        alert("글 불러오기 실패");
+        navigate(-1);
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [id, isEdit, navigate]);
 
   const handleSubmit = async (data: PostEditorFormData) => {
     try {
@@ -13,27 +51,38 @@ export default function FreePostPage() {
         ? await compressImages(data.images)
         : undefined;
 
-      const res = await createFreeBoard({
-        title: data.title,
-        content: data.content,
-        images: compressedImages,
-      });
-
-      const postId = res.data.postId;
-      console.log(postId);
-
-      navigate(`/free/${postId}`);
+      if (isEdit) {
+        await editFreeBoard(Number(id), {
+          title: data.title,
+          content: data.content,
+          images: compressedImages,
+        });
+        alert("수정 완료!");
+        navigate(`/free/${id}`);
+      } else {
+        const res = await createFreeBoard({
+          title: data.title,
+          content: data.content,
+          images: compressedImages,
+        });
+        const newPostId = res.data.postId;
+        navigate(`/free/${newPostId}`);
+      }
     } catch (e) {
       console.error(e);
       alert("작성 실패");
     }
   };
 
+  if (isEdit && loading) return <p>로딩 중...</p>;
+
   return (
     <PostEditor
       type="free"
-      title="자유 게시글 작성하기"
+      title={isEdit ? "자유 게시글 수정하기" : "자유 게시글 작성하기"}
       onSubmit={handleSubmit}
+      defaultValues={defaultValues || undefined}
+      submitText={isEdit ? "수정하기" : "작성완료"}
     />
   );
 }

--- a/src/pages/diary/DiaryPostPage.tsx
+++ b/src/pages/diary/DiaryPostPage.tsx
@@ -1,8 +1,13 @@
+import { useEffect, useState } from "react";
+import { useNavigate, useSearchParams } from "react-router-dom";
 import PostEditor from "../community/components/PostEditor";
 import { compressImages } from "@/utils/imageCompressor";
-import { useNavigate } from "react-router-dom";
+import {
+  createDiary,
+  editDiaryBoard,
+  getDiaryBoardDetail,
+} from "@/apis/community/community";
 import type { PostEditorFormData } from "../community/components/detail";
-import { createDiary } from "@/apis/community/community";
 import { toast } from "react-toastify";
 
 const PRACTICE_OPTIONS = [
@@ -15,6 +20,39 @@ const PRACTICE_OPTIONS = [
 
 export default function DiaryPostPage() {
   const navigate = useNavigate();
+  const [searchParams] = useSearchParams();
+  const editId = searchParams.get("id");
+
+  const [defaultValues, setDefaultValues] = useState<PostEditorFormData | null>(
+    null
+  );
+  const [loading, setLoading] = useState(false);
+
+  useEffect(() => {
+    if (!editId) return;
+
+    const fetchData = async () => {
+      try {
+        setLoading(true);
+        const res = await getDiaryBoardDetail(editId);
+        const post = res.data;
+
+        setDefaultValues({
+          title: post.title,
+          content: post.description,
+          dropdownValue: post.action,
+          images: [],
+        });
+      } catch (e) {
+        console.error(e);
+        toast("글 정보를 불러오지 못했어요.");
+      } finally {
+        setLoading(false);
+      }
+    };
+
+    fetchData();
+  }, [editId]);
 
   const handleSubmit = async (data: PostEditorFormData) => {
     try {
@@ -22,29 +60,46 @@ export default function DiaryPostPage() {
         ? await compressImages(data.images)
         : undefined;
 
-      const res = await createDiary({
-        title: data.title,
-        content: data.content,
-        practiceCategory: data.dropdownValue!,
-        images: compressedImages,
-      });
+      if (editId) {
+        await editDiaryBoard(Number(editId), {
+          title: data.title,
+          content: data.content,
+          practiceCategory: data.dropdownValue!,
+          images: compressedImages,
+        });
+        toast("수정되었습니다!");
+        navigate(`/diary/${editId}`);
+      } else {
+        const res = await createDiary({
+          title: data.title,
+          content: data.content,
+          practiceCategory: data.dropdownValue!,
+          images: compressedImages,
+        });
 
-      const postId = res.data.postId;
-      toast("업로드되었습니다!");
-      navigate(`/diary/${postId}`);
+        const postId = res.data.postId;
+        toast("업로드되었습니다!");
+        navigate(`/diary/${postId}`);
+      }
     } catch (e) {
       console.error(e);
-      alert("작성 실패");
+      toast("작성 실패");
     }
   };
+
+  if (editId && loading) {
+    return <p>불러오는 중...</p>;
+  }
 
   return (
     <PostEditor
       type="diary"
-      title="나의 외교실천일지"
+      title={editId ? "실천일지 수정하기" : "나의 외교실천일지"}
       dropdownLabel="항목"
       dropdownOptions={PRACTICE_OPTIONS}
       onSubmit={handleSubmit}
+      defaultValues={defaultValues ?? undefined}
+      submitText={editId ? "수정하기" : "작성 완료"}
     />
   );
 }


### PR DESCRIPTION
## 📌 관련 이슈
#13 

## ✨ 과제 내용
- 자유게시판, 토론글, 실천일지 게시글 수정 API 연동
  - 기존 작성된 게시글을 불러와 PostEditor에 기본값으로 노출
  - PostEditor 컴포넌트에서 create/edit 모드 분리
    - edit 모드 시 submit 버튼 텍스트 “수정하기”로 변경
  - 수정 시 각 게시판별 edit API 호출
  - 수정 완료 후 상세 페이지로 이동

- PreviewCard 컴포넌트에서 “수정” 버튼 클릭 시
  - `?id={postId}` 쿼리 파라미터로 PostPage로 이동하도록 변경

- PostEditor 이미지 처리
  - 현재는 수정시 빈 폼데이터를 보내는 경우, 기존의 이미지까지 삭제됨
  - 리팩토링 에정
